### PR TITLE
Update and rename GUAP-v2.3.1-MN.sh to GUAP-v2.3.0.1-MN.sh

### DIFF
--- a/GUAP-v2.3.0.1-MN.sh
+++ b/GUAP-v2.3.0.1-MN.sh
@@ -130,7 +130,7 @@ fi
 #Installing Daemon
 cd ~
 rm -rf /usr/local/bin/guapcoin*
-wget https://github.com/guapcrypto/Guapcoin/releases/download/v2.3.1/Guapcoin-2.3.1-Daemon-Ubuntu.tar.gz
+wget https://github.com/guapcrypto/Guapcoin/releases/download/v2.3.0.1/Guapcoin-2.3.0.1-Daemon-Ubuntu.tar.gz
 tar -xzvf Guapcoin-2.3.1-Daemon-Ubuntu.tar.gz
 sudo chmod -R 755 guapcoin-cli
 sudo chmod -R 755 guapcoind
@@ -195,15 +195,20 @@ externalip=$publicip:$PORT
 bind=$publicip:$PORT
 masternodeaddr=$publicip:$PORT
 masternodeprivkey=$genkey
-addnode=159.65.221.180
-addnode=45.76.61.148
+addnode=159.65.221.182
+addnode=45.76.255.103
 addnode=209.250.250.121
-addnode=136.244.112.117
-addnode=199.247.20.128
-addnode=78.141.203.208
+addnode=138.197.136.6
+addnode=198.199.68.111
+addnode=178.62.110.207
 addnode=155.138.140.38
 addnode=45.76.199.11
-addnode=45.63.25.141
+addnode=70.35.194.41
+addnode=144.202.75.140
+addnode=209.126.5.122
+addnode=95.216.27.40
+
+
 
  
 EOF


### PR DESCRIPTION
This is a update to issues encountered during 2.3.0. It is a release only for the Master nodes, all desktop wallets can remain at the current 2.3.0 version until the next release.
[Guapcoin-2.3.0.1-Daemon-Ubuntu.tar.gz](https://github.com/guapcrypto/Guapcoin-MN-Install-V2/files/5982858/Guapcoin-2.3.0.1-Daemon-Ubuntu.tar.gz)
